### PR TITLE
chore: Update to `actions/upload-artifact` v4

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -55,7 +55,7 @@ jobs:
             this is a multi-line
             release note
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: TestNuGetPackage.2.1.1
           path: ${{ steps.self_test.outputs.package_file_path }}


### PR DESCRIPTION
[V3 of artifact actions are being deprecated on Nov 30th 2024](https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/) after which time workflows will fail. This PR updates to use v4.