### PR TITLE
chore: Add protections against malicious package updates in Renovate

### DIFF
--- a/renovate-config.js
+++ b/renovate-config.js
@@ -6,13 +6,14 @@ module.exports = {
     ':ignoreModulesAndTests',
     ':pinVersions',
     ':rebaseStalePrs',
-    ':automergeDigest',
-    ':automergePatch',
+    // Automatic merging is temporarily disabled.
+    // ':automergeDigest',
+    // ':automergePatch',
     ':automergePr',
     ':automergeRequireAllStatusChecks',
-    ':automergeLinters',
-    ':automergeTesters',
-    ':automergeTypes',
+    // ':automergeLinters',
+    // ':automergeTesters',
+    // ':automergeTypes',
     'packages:eslint',
     'workarounds:typesNodeVersioning',
     'github>whitesource/merge-confidence:beta'
@@ -20,7 +21,12 @@ module.exports = {
   branchPrefix: 'renovate/',
   platform: 'github',
   repositories: ['OctopusDeploy/create-nuget-package-action'],
-  packageRules: [],
+  packageRules: [
+    {
+      matchDatasources: ['npm'],
+      minimumReleaseAge: '2 days'
+    }
+  ],
   timezone: 'Australia/Brisbane',
   onboarding: false,
   requireConfig: false,


### PR DESCRIPTION
## What's this? ⛵ 

In response to recent events with [axios compromised on npm](https://www.stepsecurity.io/blog/axios-compromised-on-npm-malicious-versions-drop-remote-access-trojan), we are adding the following to all of our repositories using Renovate auto updates: 
1) Setting a [minimum release age of two days](https://octopusdeploy.slack.com/archives/C0APW3ZBH5G/p1774934302803679?thread_ts=1774931666.271949&cid=C0APW3ZBH5G) for all npm package updates. This allows time for problems to be detected elsewhere before reaching us. 
2) Temporarily pausing automatic merging by commenting config which enables it.

### Config which allows auto-merging has been commented:
`automergeDigest` — Auto-merge digest updates (Docker image digest pins, e.g. sha256:abc...). 
`automergePatch` — Auto-merge patch version bumps (e.g. 1.2.3 → 1.2.4). 
`automergeLinters` — Auto-merge updates to linting packages (ESLint, Prettier, etc.).
`automergeTesters` — Auto-merge updates to test framework packages (Jest, Mocha, etc.).
`automergeTypes` — Auto-merge updates to @types/* packages, regardless of semver level. 

### Config which restricts auto-merging remains unchanged:
`automergePr` — Sets the automerge method to merging the PR itself (as opposed to pushing directly to the branch). 
`automergeRequireAllStatusChecks` — Only auto-merge if all status checks pass. Safety guard — prevents merging a PR that has failing CI.

Part of DEVEX-186
Part of DEVEX-187